### PR TITLE
unstableSetReplacement always returns the first file

### DIFF
--- a/Mtgdb.Dal/ImageNamePatcher.cs
+++ b/Mtgdb.Dal/ImageNamePatcher.cs
@@ -90,7 +90,7 @@ namespace Mtgdb.Dal
 		{
 			char letterNumber = match.Groups["num"].Value[0];
 
-			var result = (1 + char.GetNumericValue(letterNumber) - char.GetNumericValue('a'))
+			var result = (1 + letterNumber - 'a')
 				.ToString(Str.Culture);
 
 			return result;


### PR DESCRIPTION
char.GetNumericValue(letter) & char.GetNumericValue('a') both return -1 so every file only show the first image.

ex: Everythingamajig (a) returns Everythingamajig1 
also Everythingamajig (b) returns also Everythingamajig1
and so on.

There is no need for char.GetNumericValue()