### PR TITLE
save to XMage format now use the correct card number

### DIFF
--- a/Mtgdb.Data.Ui/Deck/Serialization/XMageDeckFormatter.cs
+++ b/Mtgdb.Data.Ui/Deck/Serialization/XMageDeckFormatter.cs
@@ -85,7 +85,7 @@ namespace Mtgdb.Ui
 				var count = zone.Count[cardId];
 				var card = Repo.CardsById[cardId];
 
-				result.AppendLine($"{prefix}{count} [{card.SetCode}:{0}] {card.NameNormalized}");
+				result.AppendLine($"{prefix}{count} [{card.SetCode}:{card.Number}] {card.NameNormalized}");
 			}
 		}
 


### PR DESCRIPTION
Solved a little bug that was preventing the export of the correct card number when saving a deck to the XMage format.